### PR TITLE
Add option for multiple identity claims

### DIFF
--- a/docs/options.rst
+++ b/docs/options.rst
@@ -23,7 +23,7 @@ Overview:
   * `JWT_ENCODE_ISSUER`_
   * `JWT_ENCODE_NBF`_
   * `JWT_ERROR_MESSAGE_KEY`_
-  * `JWT_IDENTITY_CLAIM`_
+  * `JWT_IDENTITY_CLAIMS`_
   * `JWT_PRIVATE_KEY`_
   * `JWT_PUBLIC_KEY`_
   * `JWT_REFRESH_TOKEN_EXPIRES`_
@@ -169,12 +169,12 @@ General Options:
     Default: ``"msg"``
 
 
-.. _JWT_IDENTITY_CLAIM:
-.. py:data:: JWT_IDENTITY_CLAIM
+.. _JWT_IDENTITY_CLAIMS:
+.. py:data:: JWT_IDENTITY_CLAIMS
 
-    The claim in a JWT that is used as the source of identity.
+    The list of potential claims in a JWT that is used as the source of identity.
 
-    Default: ``"sub"``
+    Default: ``["sub"]``
 
 
 .. _JWT_PRIVATE_KEY:

--- a/examples/oidc.py
+++ b/examples/oidc.py
@@ -113,7 +113,7 @@ app.config["JWT_PUBLIC_KEY"] = RSAAlgorithm.from_jwk(
 app.config["JWT_DECODE_AUDIENCE"] = OIDC_CLIENT_ID
 
 # name of token entry that will become distinct flask identity username
-app.config["JWT_IDENTITY_CLAIM"] = OIDC_USERNAME_CLAIM
+app.config["JWT_IDENTITY_CLAIMS"] = [OIDC_USERNAME_CLAIM]
 jwt = JWTManager(app)
 
 

--- a/flask_jwt_extended/__init__.py
+++ b/flask_jwt_extended/__init__.py
@@ -19,4 +19,4 @@ from .utils import unset_refresh_cookies as unset_refresh_cookies
 from .view_decorators import jwt_required as jwt_required
 from .view_decorators import verify_jwt_in_request as verify_jwt_in_request
 
-__version__ = "4.4.4"
+__version__ = "4.4.4.post1"

--- a/flask_jwt_extended/__init__.py
+++ b/flask_jwt_extended/__init__.py
@@ -19,4 +19,4 @@ from .utils import unset_refresh_cookies as unset_refresh_cookies
 from .view_decorators import jwt_required as jwt_required
 from .view_decorators import verify_jwt_in_request as verify_jwt_in_request
 
-__version__ = "4.4.4.post1"
+__version__ = "4.4.4.post2"

--- a/flask_jwt_extended/config.py
+++ b/flask_jwt_extended/config.py
@@ -272,8 +272,11 @@ class _Config(object):
         return None if self.session_cookie else 31540000  # 1 year
 
     @property
-    def identity_claim_key(self) -> str:
-        return current_app.config["JWT_IDENTITY_CLAIM"]
+    def identity_claim_keys(self) -> List[str]:
+        if current_app.config["JWT_IDENTITY_CLAIMS"]:
+            return current_app.config["JWT_IDENTITY_CLAIMS"]
+        else:
+            return [current_app.config["JWT_IDENTITY_CLAIM"]]
 
     @property
     def exempt_methods(self) -> Iterable[str]:

--- a/flask_jwt_extended/default_callbacks.py
+++ b/flask_jwt_extended/default_callbacks.py
@@ -120,7 +120,10 @@ def default_user_lookup_error_callback(
     function returns None, we return a general error message with a 401
     status code
     """
-    identity = jwt_data[config.identity_claim_key]
+    for identity_claim_key in config.identity_claim_keys:
+        if identity_claim_key in jwt_data:
+            identity = jwt_data[identity_claim_key]
+            break
     result = {config.error_msg_key: f"Error loading the user {identity}"}
     return jsonify(result), HTTPStatus.UNAUTHORIZED
 

--- a/flask_jwt_extended/jwt_manager.py
+++ b/flask_jwt_extended/jwt_manager.py
@@ -208,7 +208,7 @@ class JWTManager(object):
         app.config.setdefault("JWT_ERROR_MESSAGE_KEY", "msg")
         app.config.setdefault("JWT_HEADER_NAME", "Authorization")
         app.config.setdefault("JWT_HEADER_TYPE", "Bearer")
-        app.config.setdefault("JWT_IDENTITY_CLAIM", "sub")
+        app.config.setdefault("JWT_IDENTITY_CLAIMS", ["sub"])
         app.config.setdefault("JWT_JSON_KEY", "access_token")
         app.config.setdefault("JWT_PRIVATE_KEY", None)
         app.config.setdefault("JWT_PUBLIC_KEY", None)
@@ -518,7 +518,7 @@ class JWTManager(object):
             fresh=fresh,
             header_overrides=header_overrides,
             identity=self._user_identity_callback(identity),
-            identity_claim_key=config.identity_claim_key,
+            identity_claim_keys=config.identity_claim_keys,
             issuer=config.encode_issuer,
             json_encoder=config.json_encoder,
             secret=self._encode_key_callback(identity),
@@ -542,7 +542,7 @@ class JWTManager(object):
             "audience": config.decode_audience,
             "csrf_value": csrf_value,
             "encoded_token": encoded_token,
-            "identity_claim_key": config.identity_claim_key,
+            "identity_claim_keys": config.identity_claim_keys,
             "issuer": config.decode_issuer,
             "leeway": config.leeway,
             "secret": secret,

--- a/flask_jwt_extended/tokens.py
+++ b/flask_jwt_extended/tokens.py
@@ -38,14 +38,16 @@ def _encode_jwt(
     if isinstance(fresh, timedelta):
         fresh = datetime.timestamp(now + fresh)
 
-    identity_claim_key = identity_claim_keys[0]
+    identity_claims = {}
+    for identity_claim_key in identity_claim_keys:
+        identity_claims[identity_claim_key] = identity
 
     token_data = {
         "fresh": fresh,
         "iat": now,
         "jti": str(uuid.uuid4()),
         "type": token_type,
-        identity_claim_key: identity,
+        **identity_claims,
     }
 
     if nbf:

--- a/flask_jwt_extended/utils.py
+++ b/flask_jwt_extended/utils.py
@@ -59,7 +59,13 @@ def get_jwt_identity() -> Any:
     :return:
         The identity of the JWT in the current request
     """
-    return get_jwt().get(config.identity_claim_key, None)
+    claims = get_jwt()
+    for identity_claim_key in config.identity_claim_keys:
+        identity = claims.get(identity_claim_key, None)
+        if identity:
+            return identity
+
+    return None
 
 
 def get_jwt_request_location() -> Optional[str]:

--- a/flask_jwt_extended/view_decorators.py
+++ b/flask_jwt_extended/view_decorators.py
@@ -162,8 +162,12 @@ def _load_user(jwt_header: dict, jwt_data: dict) -> Optional[dict]:
     if not has_user_lookup():
         return None
 
-    identity = jwt_data[config.identity_claim_key]
-    user = user_lookup(jwt_header, jwt_data)
+    for identity_claim_key in config.identity_claim_keys:
+        if identity_claim_key in jwt_data:
+            identity = jwt_data[identity_claim_key]
+            user = user_lookup(jwt_header, jwt_data)
+            break
+
     if user is None:
         error_msg = "user_lookup returned None for {}".format(identity)
         raise UserLookupError(error_msg, jwt_header, jwt_data)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -69,7 +69,7 @@ def test_default_configs(app):
 
         assert config.cookie_max_age is None
 
-        assert config.identity_claim_key == "sub"
+        assert config.identity_claim_keys == ["sub"]
 
         assert config.error_msg_key == "msg"
 
@@ -112,7 +112,7 @@ def test_override_configs(app, delta_func):
     app.config["JWT_ALGORITHM"] = "HS512"
     app.config["JWT_DECODE_ALGORITHMS"] = ["HS512", "HS256"]
 
-    app.config["JWT_IDENTITY_CLAIM"] = "foo"
+    app.config["JWT_IDENTITY_CLAIMS"] = ["foo"]
 
     app.config["JWT_ERROR_MESSAGE_KEY"] = "message"
 
@@ -159,7 +159,7 @@ def test_override_configs(app, delta_func):
 
         assert config.cookie_max_age == 31540000
 
-        assert config.identity_claim_key == "foo"
+        assert config.identity_claim_keys == ["foo"]
 
         assert config.error_msg_key == "message"
 

--- a/tests/test_decode_tokens.py
+++ b/tests/test_decode_tokens.py
@@ -38,9 +38,10 @@ def app():
 @pytest.fixture(scope="function")
 def default_access_token(app):
     with app.test_request_context():
+        identity_claim_key = config.identity_claim_keys[0]
         return {
             "jti": "1234",
-            config.identity_claim_key: "username",
+            identity_claim_key: ["username"],
             "type": "access",
             "fresh": True,
             "csrf": "abcd",
@@ -170,7 +171,7 @@ def test_nbf_token_in_future(app):
 
 
 def test_alternate_identity_claim(app, default_access_token):
-    app.config["JWT_IDENTITY_CLAIM"] = "banana"
+    app.config["JWT_IDENTITY_CLAIMS"] = ["banana"]
 
     # Ensure decoding fails if the claim isn't there
     token = encode_token(app, default_access_token)

--- a/tests/test_view_decorators.py
+++ b/tests/test_view_decorators.py
@@ -314,7 +314,7 @@ def test_jwt_missing_claims(app):
 
     response = test_client.get(url, headers=make_headers(token))
     assert response.status_code == 422
-    assert response.get_json() == {"msg": "Missing claim: sub"}
+    assert response.get_json() == {"msg": "Missing claim: ['sub']"}
 
 
 def test_jwt_invalid_audience(app):


### PR DESCRIPTION
NOTE: I don’t intend on merging this PR, we can directly reference the branch/commit in our setup. Making this for review purposes

I based our fork off of the `4.4.4` release of `flask-jwt-extended` which is the one we are currently using to minimize any other potential regressions.

We add support for a new environment variable `JWT_IDENTITY_CLAIMS` which allows the JWT verification to check for identity in a list of fields instead of a single field. This allows us to support our existing auth tokens while transitioning our identity claim from `identity` over to `sub` and allows us to simultaneously verify our tokens and auth0 tokens.

If `JWT_IDENTITY_CLAIMS` doesnt exist we fallback to `JWT_IDENTITY_CLAIM` to try to prevent breaking.